### PR TITLE
chore: fix stack crash on Apple platforms

### DIFF
--- a/src/utils/utils.c
+++ b/src/utils/utils.c
@@ -1,7 +1,7 @@
 #include "utils.h"
 
 void GetProgramDir (char* buf) {
-    char str[PATH_MAX];
+  char str[PATH_MAX + 1];
 	char* dir;
 
 	#ifdef __APPLE__


### PR DESCRIPTION
For some obscure reason, `_NSGetExecutablePath(char* buf, uint32_t* bufsize)` writes `bufsize + 1` characters into `buf`, hence we are allocating the buffer as `MAX_PATH + 1`. It avoids the crash below:

```
Thread 0 Crashed::  Dispatch queue: com.apple.main-thread
0   libsystem_kernel.dylib        	       0x194d44724 __pthread_kill + 8
1   libsystem_pthread.dylib       	       0x194d7bc28 pthread_kill + 288
2   libsystem_c.dylib             	       0x194c89b74 __abort + 128
3   libsystem_c.dylib             	       0x194c7a640 __stack_chk_fail + 96
4   lvgljs                        	       0x100c780ec GetProgramDir + 192 (utils.c:24)
5   lvgljs                        	       0x100c78cd0 Engine::GetEngineDir(char*) + 28 (engine.cpp:70)
6   lvgljs                        	       0x100c78a4c Engine::GetBundlePath(char*) + 32 (engine.cpp:88)
7   lvgljs                        	       0x100c788cc Engine::Engine(char*) + 148 (engine.cpp:29)
8   lvgljs                        	       0x100c78ba8 Engine::Engine(char*) + 36 (engine.cpp:14)
9   lvgljs                        	       0x100c78eb4 main + 80 (engine.cpp:115)
10  dyld                          	       0x194a23f28 start + 2236
```