### PR TITLE
rander/util: Make NormalizePx support negative numbers

### DIFF
--- a/src/render/react/core/style/util.js
+++ b/src/render/react/core/style/util.js
@@ -6,7 +6,7 @@ export function NormalizePx(value) {
     return value;
   }
   value = value.replace(/(^\s*)|(\s*$)/g, "");
-  const reg = /(\d+\.?\d*)(px)?$/;
+  const reg = /(-?\d+\.?\d*)(px)?$/;
   value = value.match(reg)?.[1];
 
   if (!isNaN(value)) {


### PR DESCRIPTION
Negative numbers cannot be supported when using shadow-offset-x/y, 
causing the shadow to be effective in only one direction.