### PR TITLE
Modify `make demo` to support different demo projects; update readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,12 @@ simulator:
 	cmake -B "$(BUILD_SIM)" -DCMAKE_BUILD_TYPE=Simulator
 	cmake --build $(BUILD_SIM)
 
+# Set default project argument to 'widgets' if no project is provided
 demo: simulator
-	node build.js
-	./${BUILD_SIM}/lvgljs run demo/widgets/index.js
+	@PROJECT=$${PROJECT:-widgets}; \
+	echo "Running demo with project: $$PROJECT"; \
+	node build.js; \
+	./${BUILD_SIM}/lvgljs run demo/$$PROJECT/index.js
 
 clean:
 	rm -rf $(BUILD_SIM)

--- a/doc/build/build-simulator.md
+++ b/doc/build/build-simulator.md
@@ -2,24 +2,27 @@
 This guide gives an overview on how to build lvgljs running with SDL simulator.
 This should work the same for both Linux and macOS.
 
-Take a look at the [txiki readme](https://github.com/saghul/txiki.js#building)
-for the required dependencies.
-You will need to install them, since we depend on txiki for the JavaScript runtime.
+## Setup
+You'll need to install these dependencies:
+- [cmake](https://cmake.org/) 
+- [sdl2](https://www.libsdl.org/)
+- [Node.js](https://nodejs.org/en/download/package-manager)
 
-Besides that you will need to install sdl2 and [Node.js](https://nodejs.org/en/download/package-manager)
+| Mac | Linux |
+| ------- | ------- |
+| `brew install cmake sdl2 node` | `sudo apt install cmake nodejs libsdl2-dev` |
 
-> [!TIP]
-> On some distributions, like Ubuntu, you might need to install the `libsdl2-dev` package as well
 
-The [`Makefile`](../../Makefile) of this repository contains some useful shortcuts:
-- `make setup` will initialize the git submodules and install the necessary npm packages
-- `make demo` will build the simulator and run the widgets demo
+Then run `make setup`. This will initialize the git submodules and install the necessary npm packages
 
-## Manual approach
-You can build the simulator with `make simulator`, which will then be available in the `build/` directory.
+## Running the demo
 
-Run `node build.js` to create `*.js` files from the `*.jsx` files in the `test/` and `demo/` directories.
-You can then run any of them with:
+`make demo` will build the simulator and run the widgets demo. Optionally you can add `PROJECT=<demoName>` where `demoName` is the directory in `/demos`, if you want to run a specific project e.g. `make demo PROJECT=calculator`
+
+## Running other projects
+1. Build the simulator with `make simulator`, which will then be available in the `build/` directory.
+2. Run `node build.js` to generate `*.js` files from the `*.jsx` files in the `test/` and `demo/` directories.
+3. Run the simulator with the generated file e.g.:
 ```sh
 ./build/lvgljs run test/button/2/index.js
 ```


### PR DESCRIPTION
Hi, I've been trying to get this project to run and have a couple of suggestions for how the DX might be slightly easier

1. Allow for passing a custom demo project name into the `make demo` command
2. Updates readme to clearly outline dependencies

I found when installing this on my Mac I only needed Node, cmake and and sdl2. The other dependencies from txiki weren't required and it makes the guide harder to follow if you need to reference another website. I ended up pulling and building txiki as I wasn't sure what this project needed. Hopefully these updates to the readme make it a bit clearer :)

Open to edits if I've got something wrong or you feel like it could be simpler