### PR TITLE
Mem leak fix

### DIFF
--- a/src/render/native/components/component.hpp
+++ b/src/render/native/components/component.hpp
@@ -284,7 +284,10 @@ void NativeComponentMaskInit (JSContext* ctx, JSValue ns);
 #define WRAPPED_JS_CLOSE_COMPONENT(COMPONENT,COMPONENT_NAME)                                                                \
     static JSValue NativeCompCloseComponent(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {          \
         COMP_REF* s = (COMP_REF*)JS_GetOpaque(this_val, COMPONENT##ClassID);                                                \
-        lv_obj_del_async(((BasicComponent*)(s->comp))->instance);                                                           \
+        if (s && s->comp) {                                                                                                 \
+            delete (BasicComponent*)(s->comp);                                                                              \
+            s->comp = nullptr;                                                                                              \
+        }                                                                                                                   \
         return JS_UNDEFINED;                                                                                                \
     }                                                                                                                       \
                                                                                                                             \

--- a/src/render/native/core/basic/comp.cpp
+++ b/src/render/native/core/basic/comp.cpp
@@ -46,7 +46,9 @@ void BasicComponent::insertChildBefore(void *child) {
 };
 
 void BasicComponent::removeChild(void* child) {
-    lv_obj_del_async((static_cast<BasicComponent*>(child))->instance);
+    // No-op only. Reconciler detachInstance closes children before parents so
+    // lv_obj_del on the parent does not cascade-delete live child widgets. Do not
+    // reparent to GetWindowInstance() here; teardown order is owned by JS.
 };
 
 void BasicComponent::appendChild (void* child) {
@@ -255,8 +257,18 @@ BasicComponent::~BasicComponent () {
     if (ptr2) {
         free((lv_coord_t*)(ptr2));
     }
-    // do not del here, remove child will do the action
-    // lv_obj_del(this->instance);
+
+    for(auto &style : style_map) {
+        lv_style_reset(style.second);
+    }
+
+    // close() deletes this object; JS unRegistEvent clears handlers but cannot reach
+    // the LVGL callback on the finalizer-only path. Detach callback before lv_obj_del.
+    lv_obj_remove_event_cb(this->instance, &BasicComponent::EventCallback);
+    if (this->instance != nullptr && lv_obj_is_valid(this->instance)) {
+        lv_obj_del(this->instance);
+    }
+    this->instance = nullptr;
 };
 
 void BasicComponent::setAlign (int32_t align_type, int32_t x, int32_t y) {

--- a/src/render/react/core/reconciler/index.js
+++ b/src/render/react/core/reconciler/index.js
@@ -8,11 +8,56 @@ export const getUid = () => {
   return String(id++);
 };
 
+const HOST_CHILDREN = Symbol("hostChildren");
+const DETACHED = Symbol("detached");
+
+// React reconciler 0.25.1 may skip per-child removeChild when an entire subtree is
+// deleted (e.g. Mask + Calendar). Track host children ourselves so detachInstance can
+// walk and close them before the parent.
+
 const instanceMap = new Map();
 
 export const getInstance = (uid) => {
-  return instanceMap[uid];
+  return instanceMap.get(uid);
 };
+
+function trackHostChild(parent, child) {
+  if (!parent || !child) return;
+  if (!parent[HOST_CHILDREN]) {
+    parent[HOST_CHILDREN] = new Set();
+  }
+  parent[HOST_CHILDREN].add(child);
+}
+
+function untrackHostChild(parent, child) {
+  parent?.[HOST_CHILDREN]?.delete(child);
+}
+
+function mountHostChild(parent, child, attach) {
+  trackHostChild(parent, child);
+  attach();
+}
+
+function detachInstance(instance) {
+  if (!instance?.uid || instance[DETACHED]) return;
+  instance[DETACHED] = true;
+
+  const children = instance[HOST_CHILDREN];
+  if (children) {
+    // Close children before this instance. LVGL deletes all child lv_objs when a
+    // parent is lv_obj_del'd; child close() must run first while the parent still
+    // exists. Native removeChild does not reparent to the window root for this.
+    for (const child of [...children]) {
+      detachInstance(child);
+    }
+    instance[HOST_CHILDREN] = undefined;
+  }
+
+  unRegistEvent(instance.uid);
+  instanceMap.delete(instance.uid);
+  instance.style = null;
+  instance.close?.();
+}
 
 const HostConfig = {
   now: Date.now,
@@ -53,7 +98,6 @@ const HostConfig = {
       workInProgress,
       uid,
     );
-    instanceMap[uid] = instance;
     return instance;
   },
   createTextInstance: (
@@ -77,16 +121,16 @@ const HostConfig = {
     // );
   },
   appendInitialChild: (parent, child) => {
-    parent.appendChild(child);
+    mountHostChild(parent, child, () => parent.appendChild(child));
   },
   appendChild(parent, child) {
-    parent.appendChild(child);
+    mountHostChild(parent, child, () => parent.appendChild(child));
   },
   finalizeInitialChildren: (yueElement, type, props) => {
     return true;
   },
   insertBefore: (parent, child, beforeChild) => {
-    parent.insertBefore(child, beforeChild);
+    mountHostChild(parent, child, () => parent.insertBefore(child, beforeChild));
   },
   supportsMutation: true,
   appendChildToContainer: function (container, child) {
@@ -97,9 +141,7 @@ const HostConfig = {
   },
   removeChildFromContainer: (container, child) => {
     container.delete(child);
-    if (child.close) {
-      child.close();
-    }
+    detachInstance(child);
   },
   prepareUpdate(instance, oldProps, newProps) {
     return true;
@@ -124,12 +166,19 @@ const HostConfig = {
   commitTextUpdate(textInstance, oldText, newText) {
     textInstance.setText(newText);
   },
+  detachDeletedInstance: (instance) => {
+    detachInstance(instance);
+  },
   removeChild(parent, child) {
-    parent?.removeChild(child);
-    unRegistEvent(child.uid);
-    delete instanceMap[child.uid];
+    untrackHostChild(parent, child);
+    // close() first so lv_obj is freed before any parent teardown touches the tree
+    detachInstance(child);
+
+    // removeChild is an no-op that will be removed in future, no need call it
+    // parent?.removeChild(child);
   },
   commitMount: function (instance, type, newProps, internalInstanceHandle) {
+    instanceMap.set(instance.uid, instance);
     const { commitMount } = getComponentByTagName(type);
     return commitMount(instance, newProps, internalInstanceHandle);
   },


### PR DESCRIPTION



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes native and React reconciler memory leaks by properly detaching and deleting components. Prevents `comp_map` growth, double frees, and orphaned instances; adds leak probes and a CLI test runner with faster builds.

- **Bug Fixes**
  - Native: make `close()` idempotent in `WRAPPED_JS_CLOSE_COMPONENT` (guard `s`/`s->comp`, delete `BasicComponent`, set `nullptr`); make `removeChild` a no-op (no reparenting; JS owns teardown); destructor resets styles, removes event callback, deletes LVGL instance if valid, then nulls it.
  - React reconciler: use `instanceMap.set/get/delete`; track host children; `detachInstance` recursively closes children before the parent, guards double-detach, unregisters events, clears style, then `close()`; applied in `removeChild`, `removeChildFromContainer`, and `detachDeletedInstance`.

- **New Features**
  - Leak probes: add `RenderUtil.getCompMapSize()` and `updateTestTree()` in `lvgljs-ui`.
  - CLI runtime tests (`binding-leak`, `calendar-leak`) and parallel `esbuild` for faster test builds.

<sup>Written for commit f14e6e2ca3fbc12dac8d45de3a213879e4273297. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lvgl/lv_binding_js/pull/60?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



Closes: https://github.com/lvgl/lv_binding_js/issues/19
